### PR TITLE
webhookhandler: Fix exception thrown during error handling

### DIFF
--- a/telegram/utils/webhookhandler.py
+++ b/telegram/utils/webhookhandler.py
@@ -62,11 +62,16 @@ class WebhookServer(BaseHTTPServer.HTTPServer, object):
     def shutdown(self):
         with self.shutdown_lock:
             if not self.is_running:
-                self.logger.warn('Webhook Server already stopped.')
+                self.logger.warning('Webhook Server already stopped.')
                 return
             else:
                 super(WebhookServer, self).shutdown()
                 self.is_running = False
+
+    def handle_error(self, request, client_address):
+        """Handle an error gracefully."""
+        self.logger.debug('Exception happened during processing of request from %s',
+                          client_address, exc_info=True)
 
 
 # WebhookHandler, process webhook calls


### PR DESCRIPTION
BaseServer.handle_error() default behaviour is to print to stdout or
stderr (depends on the python version). In case that the file descriptor
is closed an additional exception will be raised, resulting with the
webhook thread to quit.

Fixes #970